### PR TITLE
Add deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,42 @@
+name: Deploy
+on: push
+
+jobs:
+  deploy:
+    name: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Java & Gradle
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: temurin
+          cache: gradle
+      - name: Compute version
+        id: compute-version
+        env:
+          SNAPSHOT_VERSION_SUFFIX: -SNAPSHOT
+          REF: ${{ github.ref_name == github.event.repository.default_branch && '' || format('-{0}', github.ref_name) }}
+        run: |
+          # Get current version of project
+          version=$(gradle printVersion -q --console=plain)
+          # Check if version ends with snapshot suffix
+          if [ ${version:(-${#SNAPSHOT_VERSION_SUFFIX})} ]; then
+            # Insert ref before snapshot suffix
+            version=${version%$SNAPSHOT_VERSION_SUFFIX}$REF$SNAPSHOT_VERSION_SUFFIX
+          else
+            # Append ref to the version
+            version=$version$REF
+          fi
+          # Save computed version
+          echo "Computed version: $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Gradle build
+        run: gradle -Pversion=${{ steps.compute-version.outputs.version }} build
+      - name: Gradle publish
+        env:
+          PUBLISH_USERNAME: ${{ secrets.PUBLISH_USERNAME }}
+          PUBLISH_PASSWORD: ${{ secrets.PUBLISH_PASSWORD }}
+        run: gradle -Pversion=${{ steps.compute-version.outputs.version }} publish

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
 }
 
 group = "dev.bazhard.library"
-version = "1.0.0-SNAPSHOT"
 description = "A 3D GUI library for Minecraft plugins"
 
 java {
@@ -30,16 +29,16 @@ publishing {
             name = "snapshot"
             url = uri("https://repo.bazhard.dev/repository/maven-snapshots/")
             credentials {
-                username = mavenCredentials?.first ?: ""
-                password = mavenCredentials?.second ?: ""
+                username = mavenCredentials?.first ?: System.getenv("PUBLISH_USERNAME") ?: ""
+                password = mavenCredentials?.second ?: System.getenv("PUBLISH_PASSWORD") ?: ""
             }
         }
         maven {
             name = "release"
             url = uri("https://repo.bazhard.dev/repository/maven-releases/")
             credentials {
-                username = mavenCredentials?.first ?: ""
-                password = mavenCredentials?.second ?: ""
+                username = mavenCredentials?.first ?: System.getenv("PUBLISH_USERNAME") ?: ""
+                password = mavenCredentials?.second ?: System.getenv("PUBLISH_PASSWORD") ?: ""
             }
         }
     }
@@ -47,7 +46,7 @@ publishing {
 
 repositories {
     mavenCentral()
-    maven( "https://repo.dmulloy2.net/repository/public/") // Required for ProtocolLib
+    maven("https://repo.dmulloy2.net/repository/public/") // Required for ProtocolLib
     maven("https://repo.papermc.io/repository/maven-public/")
 }
 
@@ -69,6 +68,18 @@ tasks {
     }
     javadoc {
         options.encoding = Charsets.UTF_8.name() // We want UTF-8 for everything
+    }
+}
+
+tasks.withType<PublishToMavenRepository>().configureEach {
+    onlyIf("publishing snapshots to the snapshot repository and releases to the release repository") {
+        repository == publishing.repositories[if (version.toString().endsWith("-SNAPSHOT")) "snapshot" else "release"]
+    }
+}
+
+tasks.register("printVersion") {
+    doLast {
+        println(project.version)
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+# Project version
+version=1.0.0-SNAPSHOT


### PR DESCRIPTION
Automatically builds and publishes project on push.

Project version is computed using specified version in `gradle.properties` and branch name (when not on default branch). When project version ends with `-SNAPSHOT`, branch name is inserted before.

Examples:
- Pushing `1.0-SNAPSHOT` on branch `feature` deploys version `1.0-feature-SNAPSHOT`
- Pushing `1.0` on branch `feature` deploys version `1.0-feature`
- Pushing `1.0-SNAPSHOT` on default branch deploys version `1.0-SNAPSHOT`
- Pushing `1.0` on default branch deploys version `1.0`

Another workflow may be added later to deploy `on: release`.